### PR TITLE
Fix grid home

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,29 @@
 #app {
     height: 100%;
 }
+
+/* width */
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+/* Track */
+::-webkit-scrollbar-track {
+  background: transparent;
+  border: 1px solid #C7C7C7;
+  border-radius: 6px;
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: #C8C8C8;
+  border-radius: 6px;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
   
   html,
   body {

--- a/src/components/Drawer/SideDrawer.tsx
+++ b/src/components/Drawer/SideDrawer.tsx
@@ -27,7 +27,7 @@ export default function SideDrawer() {
           }}
         >
           <DrawerItem name='Home' icon={home} path='/' variant='unselected' />
-          <DrawerItem name='Turma' icon={turma} path='/turma' variant='turma-selected' />
+          <DrawerItem name='Turmas' icon={turma} path='/turma' variant='turma-selected' />
           <DrawerItem name='Criar Material' icon={material} path='/educacao' variant='unselected' color='#6730EC' />
           <DrawerItem name='Fale com o edu' icon={chat} path='/avaliacao' variant='unselected' color='#6730EC' />
         </Stack>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Typography from '@mui/material/Typography'
-import Modal from '@mui/material/Modal'
 import Divider from '@mui/material/Divider'
+import Modal from '@mui/material/Modal'
+import Typography from '@mui/material/Typography'
+import * as React from 'react'
+import { FiPlusCircle } from 'react-icons/fi'
 
 type ModalProps = {
   variantButton: 'sm' | 'lg' | 'novaTurma'
@@ -33,7 +34,7 @@ export default function BasicModal(props: ModalProps) {
   const variantsButtonStyle = {
     'novaTurma':
     {
-      width: '14%'
+      width: 'fix-content'
     },
     'sm': {
       width: '48%'
@@ -52,18 +53,21 @@ export default function BasicModal(props: ModalProps) {
   return (
     <>
       <Button sx={{
+        borderRadius: 25,
+        textTransform: 'capitalize',
         display: 'flex',
+        gap: '16px',
+        justifyContent: 'space-between',
         borderColor: '#5D1EF4',
-        gap: '10px',
         '&:hover': {
           backgroundColor: '#D8D8D8'
         },
         ...sxButton
-      }} variant='outlined' onClick={handleOpen}>
+      }} startIcon={<FiPlusCircle size={25}/>} variant='outlined' onClick={handleOpen}>
         {!isNovaTurmaButton && (
           <img src='/iconsPages/plus-circle.svg' alt='Circulo com um mais dentro' />
         )}
-        <Typography variant='body1' color='black'>{textoBotaoAbrirModal}</Typography>
+        <Typography variant='body1' color='#170050' fontWeight={700}>{textoBotaoAbrirModal}</Typography>
       </Button>
       <Modal
         open={open}

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,12 +1,12 @@
+import TabContext from '@mui/lab/TabContext'
 import Box from '@mui/material/Box/Box'
 import Divider from '@mui/material/Divider/Divider'
 import Tab from '@mui/material/Tab'
-import TabContext from '@mui/lab/TabContext'
-import { useNavigate } from 'react-router-dom'
-import Typography from '@mui/material/Typography/Typography'
-import { useState } from 'react'
 import Tabs from '@mui/material/Tabs/Tabs'
 import TextField from '@mui/material/TextField/TextField'
+import Typography from '@mui/material/Typography/Typography'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import Modal from '../Modal/Modal'
 
 type PageHeaderProps = {

--- a/src/components/Turma/Turma.tsx
+++ b/src/components/Turma/Turma.tsx
@@ -1,9 +1,9 @@
-import Box from '@mui/material/Box/Box'
-import Typography from '@mui/material/Typography/Typography'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import Box from '@mui/material/Box/Box'
 import IconButton from '@mui/material/IconButton/IconButton'
-import MenuItem from '@mui/material/MenuItem/MenuItem'
 import Menu from '@mui/material/Menu/Menu'
+import MenuItem from '@mui/material/MenuItem/MenuItem'
+import Typography from '@mui/material/Typography/Typography'
 import { useState } from 'react'
 
 type TurmaProps = {
@@ -33,23 +33,32 @@ export default function Turma(props: TurmaProps) {
     }
 
     return (
-        <Box sx={{ cursor: 'pointer', width: '15vw', height: '14vh', border: '2px solid #BEBEBE', borderRadius: '10px' }}
-            onClick={onClick} >
+        <Box sx={{ 
+            cursor: 'pointer', 
+            width: '15vw', 
+            height: '14vh', 
+            border: '1px solid #BEBEBE', 
+            borderRadius: '10px', 
+            boxShadow: '0px 2px 3px 1px #00000012',
+            userSelect: 'none'
+        }} 
+        onClick={onClick}>
             <Box sx={{
                 width: '100%',
                 height: '35%',
                 display: 'flex',
                 flexDirection: 'row',
                 justifyContent: 'space-between',
-                padding: '8px',
-                borderBottom: '2px solid #BEBEBE',
+                paddingLeft: '16px',
+                paddingRight: '6px',
+                borderBottom: '1px solid #BEBEBE',
                 borderColor: '#BEBEBE'
             }}>
                 <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', width: '60%', alignItems: 'center', gap: '10px' }}>
-                    <img src='./logos/bookTwo.svg' alt='Ícone de livro' style={{ width: '26px', marginBottom: '5px' }} />
-                    <Typography sx={{ fontSize: '16px', whiteSpace: 'nowrap' }}>{nome}</Typography>
+                    <img src='./logos/bookTwo.svg' alt='Ícone de livro' style={{ width: '26px', marginBottom: '3px' }} />
+                    <Typography sx={{ fontSize: '16px', whiteSpace: 'nowrap', fontWeight: 500 }}>{nome}</Typography>
                 </Box>
-                <IconButton size='small' onClick={handleClick}>
+                <IconButton sx={{ justifyContent: 'end' }} size='small' onClick={handleClick}>
                     <MoreVertIcon />
                 </IconButton>
                 <Menu
@@ -66,9 +75,16 @@ export default function Turma(props: TurmaProps) {
                     </MenuItem>
                 </Menu>
             </Box>
-            <Box sx={{ width: '100%', height: '65%', padding: '8px', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-                <Typography>Disciplina: {disciplina}</Typography>
-                <Typography>Quantidade de alunos: {qtdAlunos}</Typography>
+            <Box sx={{ width: '100%', height: '65%', padding: '8px 16px', display: 'flex', flexDirection: 'column', justifyContent: 'space-evenly' }}>
+                <Typography sx={{ display: 'flex', gap: '4px', fontSize: 14, color: '#5E5E5E' }}>
+                    Disciplina: 
+                    <Typography sx={{ color: "#5E5E5E", fontWeight: 700, fontSize: 14 }}>{disciplina}</Typography>
+                </Typography>
+
+                <Typography sx={{ display: 'flex', gap: '4px', fontSize: 14, color: '#5E5E5E' }}>
+                    Quantidade de alunos: 
+                    <Typography sx={{ color: "#5E5E5E", fontWeight: 700, fontSize: 14 }}>{qtdAlunos}</Typography>
+                </Typography>
             </Box>
         </Box>
     )

--- a/src/components/Turma/Turma.tsx
+++ b/src/components/Turma/Turma.tsx
@@ -34,7 +34,7 @@ export default function Turma(props: TurmaProps) {
     }
 
     return (
-        <Box sx={{ width: '15vw', height: '14vh', border: '2px solid #BEBEBE', borderRadius: '10px', backgroundColor: 'green' }}
+        <Box sx={{ cursor: 'pointer', width: '15vw', height: '14vh', border: '2px solid #BEBEBE', borderRadius: '10px' }}
             onClick={onClick} >
             <Box sx={{
                 width: '100%',

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -8,6 +8,9 @@ const theme = createTheme({
     secondary: {
       main: '#00000',
     },
+  },
+  typography: {
+    fontFamily: 'Montserrat'
   }
 })
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,11 +1,11 @@
 import Box from '@mui/material/Box/Box'
-import PageHeader from '../components/PageHeader/PageHeader'
-import Layout from './Layout'
-import Turma from '../components/Turma/Turma'
 import { useNavigate } from 'react-router-dom'
+import PageHeader from '../components/PageHeader/PageHeader'
+import Turma from '../components/Turma/Turma'
+import Layout from './Layout'
 
 export default function Home() {
-  const turmasArray = Array.from({ length: 10 })
+  const turmasArray = Array.from({ length: 60 })
   const navigate = useNavigate()
 
   const handleClick = (index: number) => {
@@ -19,9 +19,9 @@ export default function Home() {
         <Box sx={{ width: '100%', justifyContent: 'center', display: 'flex' }}>
           <PageHeader title='Turmas' />
         </Box>
-        <Box sx={{ display: 'grid', padding: '24px', gap: 2, 
+        <Box sx={{ display: 'grid', padding: '24px 42px', gap: 2, 
         gridTemplateColumns: 'repeat(auto-fill, minmax(18%, 1fr))', gridTemplateRows: 'max-content',
-        flex: '1', overflowY: 'scroll'}}>
+        flex: '1', overflowY: 'auto'}}>
           {turmasArray.map((_, index) => (
             <Turma key={index} nome='Turma 1' disciplina='Matemática' qtdAlunos={20} onClick={() => handleClick(index)}/>
           ))}

--- a/src/pages/Turmas.tsx
+++ b/src/pages/Turmas.tsx
@@ -5,7 +5,7 @@ import Turma from '../components/Turma/Turma'
 import { useNavigate } from 'react-router-dom'
 
 export default function Turmas() {
-  const turmasArray = Array.from({ length: 10 })
+  const turmasArray = Array.from({ length: 50 })
   const navigate = useNavigate()
 
   const handleClick = (index: number) => {
@@ -15,13 +15,13 @@ export default function Turmas() {
 
   return (
     <Layout>
-      <Box sx={{ width: '100%' }} >
+      <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column' }} >
         <Box sx={{ width: '100%', justifyContent: 'center', display: 'flex' }}>
           <PageHeader title='Turmas' />
         </Box>
-        <Box sx={{ width: '100%', height: '89%', display: 'flex', padding: '24px', backgroundColor: 'red',
-          flexBasis: '100%', flexShrink: 0, flexGrow: 1, flexWrap: 'wrap', gap: '5px'
-         }}>
+        <Box sx={{ display: 'grid', padding: '24px', gap: 2, 
+        gridTemplateColumns: 'repeat(auto-fill, minmax(18%, 1fr))', gridTemplateRows: 'max-content',
+        flex: '1', overflowY: 'scroll'}}>
           {turmasArray.map((_, index) => (
             <Turma key={index} nome='Turma 1' disciplina='Matemática' qtdAlunos={20} onClick={() => handleClick(index)}/>
           ))}


### PR DESCRIPTION
## Objetivo

- Ajustar grid da home de turmas de modo que todas as turmas sejam exibidas
- Ajustar container para fazer scroll dentro do container das turmas
- Ajustar fontes
- Ajustar botão de Nova Turma
- Ajustar style do scroll para ficar igual ao do protótipo

## Screenshots

![image](https://github.com/educ-ai-org/educai-web-app/assets/79378858/592d3b36-35c8-4933-99d4-88ba82a3088b)
