### PR TITLE
EA-8 | Arrumando o bug do layout turma

### DIFF
--- a/src/components/Turma/Turma.tsx
+++ b/src/components/Turma/Turma.tsx
@@ -101,7 +101,7 @@ export default function Turma(props: TurmaProps) {
     }
 
     return (
-        <Box>
+        <>
             <Box sx={{
                 cursor: 'pointer',
                 width: '16vw',
@@ -109,7 +109,9 @@ export default function Turma(props: TurmaProps) {
                 border: '1px solid #BEBEBE',
                 borderRadius: '10px',
                 boxShadow: '0px 2px 3px 1px #00000012',
-                userSelect: 'none'
+                userSelect: 'none',
+                marginBottom: '36px',
+                marginRight: '54px'
             }} onClick={onClick}>
                 <Box sx={{
                     width: '100%',
@@ -245,6 +247,6 @@ export default function Turma(props: TurmaProps) {
                     </Box>
                 </Modal>
             </Box>
-        </Box>
+        </>
     )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -120,7 +120,7 @@ export default function Home() {
 
   return (
     <Layout>
-      <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column' }} >
+      <Box sx={{ width: '100%', height:'100%', display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'center' }} >
         <Box sx={{ width: '100%', justifyContent: 'center', display: 'flex' }}>
           <PageHeader
             search={{ searchValue: search, setSearchValue: setSearch, onSearch: searchClassrooms }}
@@ -130,9 +130,13 @@ export default function Home() {
           />
         </Box>
         <Box sx={{
-          display: 'grid', padding: '24px 42px', gap: 2,
-          gridTemplateColumns: 'repeat(auto-fill, minmax(20%, 1fr))', gridTemplateRows: 'max-content',
-          flex: '1', overflowY: 'auto'
+          width: '95%',
+          flexWrap: 'wrap',
+          display: 'flex',
+          flexDirection: 'row',
+          overflowY: 'auto',
+          height: '85%',
+          alignContent: 'start',
         }}>
           {turmas && !turmaSearch && turmas.map((turma, index) => (
             <Turma


### PR DESCRIPTION
## Objetivo
Arumando o bug do layout quando tem muitas turmas 

## Screenshots

![image](https://github.com/educ-ai-org/educai-web-app/assets/73249218/431f2009-71d4-47f5-87d8-bcafff43597e)

## Referências

https://educ-ai.atlassian.net/jira/software/projects/EA/boards/1?selectedIssue=EA-8